### PR TITLE
bump `starknet-rs` to `0.11.0` + migrate to new `Felt` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,4 @@ url = "2.5.0"
 serde-felt = { path = "./serde-felt" }
 
 starknet = "0.11.0"
-# serde-starknet = { package = "starknet", version = "=0.10.0" }
-starknet-types-core = "~0.1.4"
-# starknet-ff = "0.3.7"
-
-# [patch.crates-io]
-# # Remove this patch once the following PR is merged: <https://github.com/xJonathanLEI/starknet-rs/pull/615>
-# #
-# # To enable std feature on `starknet-types-core`.
-# # To re-export the entire `felt` module from `starknet-types-core`.
-# starknet-core = { git = "https://github.com/kariy/starknet-rs", branch = "dojo-patch" }
+starknet-types-core = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "proof-parser", "serde-felt",
-]
+members = ["proof-parser", "serde-felt"]
 
 [workspace.package]
 version = "0.1.0"
@@ -17,9 +15,19 @@ prefix-hex = "0.7.1"
 regex = "1.10.4"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
-starknet = "0.10.0"
-starknet-crypto = { version = "0.6.2", features = ["alloc"] }
+starknet-crypto = { version = "0.7.1", features = ["alloc"] }
 tokio = { version = "1.37.0", features = ["full"] }
 url = "2.5.0"
 serde-felt = { path = "./serde-felt" }
-starknet-ff = "0.3.7"
+
+starknet = "0.11.0"
+# serde-starknet = { package = "starknet", version = "=0.10.0" }
+starknet-types-core = "~0.1.4"
+# starknet-ff = "0.3.7"
+
+# [patch.crates-io]
+# # Remove this patch once the following PR is merged: <https://github.com/xJonathanLEI/starknet-rs/pull/615>
+# #
+# # To enable std feature on `starknet-types-core`.
+# # To re-export the entire `felt` module from `starknet-types-core`.
+# starknet-core = { git = "https://github.com/kariy/starknet-rs", branch = "dojo-patch" }

--- a/proof-parser/Cargo.toml
+++ b/proof-parser/Cargo.toml
@@ -39,6 +39,7 @@ regex.workspace = true
 serde.workspace = true
 serde-felt.workspace = true
 serde_json.workspace = true
+starknet-types-core.workspace = true
 starknet.workspace = true
 starknet-crypto.workspace = true
 tokio.workspace = true

--- a/proof-parser/src/bin/register_fact.rs
+++ b/proof-parser/src/bin/register_fact.rs
@@ -8,7 +8,7 @@ use serde_felt::to_felts;
 use starknet::accounts::ConnectedAccount;
 use starknet::accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::{
-    BlockId, BlockTag, FieldElement, TransactionExecutionStatus, TransactionStatus,
+    BlockId, BlockTag, Felt, TransactionExecutionStatus, TransactionStatus,
 };
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
@@ -37,20 +37,18 @@ struct Cli {
 async fn main() -> anyhow::Result<()> {
     let args = Cli::parse(); // Automatically parse command line arguments
 
-    let address = FieldElement::from_hex_be(&args.address).expect("Invalid signer address hex");
-    let key = SigningKey::from_secret_scalar(
-        FieldElement::from_hex_be(&args.key).expect("Invalid signer key hex"),
-    );
+    let address = Felt::from_hex(&args.address).expect("Invalid signer address hex");
+    let key =
+        SigningKey::from_secret_scalar(Felt::from_hex(&args.key).expect("Invalid signer key hex"));
 
     // Setup StarkNet provider and wallet
     let provider = JsonRpcClient::new(HttpTransport::new(
         Url::parse("https://free-rpc.nethermind.io/sepolia-juno/v0_7").unwrap(),
     ));
     let signer = LocalWallet::from(key);
-    let chain_id = FieldElement::from_hex_be(
-        "0x00000000000000000000000000000000000000000000534e5f5345504f4c4941",
-    )
-    .unwrap();
+    let chain_id =
+        Felt::from_hex("0x00000000000000000000000000000000000000000000534e5f5345504f4c4941")
+            .unwrap();
     let mut account =
         SingleOwnerAccount::new(provider, signer, address, chain_id, ExecutionEncoding::New);
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
@@ -81,14 +79,12 @@ async fn main() -> anyhow::Result<()> {
 
 async fn verify_and_register_fact(
     account: SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
-    serialized_proof: Vec<FieldElement>,
+    serialized_proof: Vec<Felt>,
 ) -> anyhow::Result<String> {
     let tx = account
-        .execute(vec![Call {
-            to: FieldElement::from_hex_be(
-                "0x282969f3212819740d03929f52c709bc62f4c2ce8c17b5f24bd835a03cca22",
-            )
-            .expect("invalid world address"),
+        .execute_v1(vec![Call {
+            to: Felt::from_hex("0x282969f3212819740d03929f52c709bc62f4c2ce8c17b5f24bd835a03cca22")
+                .expect("invalid world address"),
             selector: get_selector_from_name("verify_and_register_fact").expect("invalid selector"),
             calldata: serialized_proof,
         }])

--- a/proof-parser/src/json_parser.rs
+++ b/proof-parser/src/json_parser.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context};
 use num_bigint::BigUint;
 use serde::Deserialize;
 use serde_felt::from_felts_with_lengths;
-use starknet_crypto::FieldElement;
+use starknet_types_core::felt::Felt;
 
 use crate::{
     annotations::Annotations,
@@ -59,11 +59,11 @@ pub struct PublicInput {
     rc_max: u32,
 }
 
-pub fn bigint_to_fe(bigint: &BigUint) -> FieldElement {
-    FieldElement::from_hex_be(&bigint.to_str_radix(16)).unwrap()
+pub fn bigint_to_fe(bigint: &BigUint) -> Felt {
+    Felt::from_hex(&bigint.to_str_radix(16)).unwrap()
 }
 
-pub fn bigints_to_fe(bigint: &[BigUint]) -> Vec<FieldElement> {
+pub fn bigints_to_fe(bigint: &[BigUint]) -> Vec<Felt> {
     bigint.iter().map(bigint_to_fe).collect()
 }
 
@@ -176,7 +176,7 @@ impl ProofJSON {
         public_input: PublicInput,
         // z: BigUint,
         // alpha: BigUint,
-    ) -> anyhow::Result<CairoPublicInput<FieldElement>> {
+    ) -> anyhow::Result<CairoPublicInput<Felt>> {
         let continuous_page_headers = vec![];
         // Self::continuous_page_headers(&public_input.public_memory, z, alpha)?; this line does for now anyway
         let main_page = Self::main_page(&public_input.public_memory)?;
@@ -187,8 +187,7 @@ impl ProofJSON {
             .map(|e| {
                 Ok((
                     e.0,
-                    FieldElement::from_hex_be(&e.1.to_str_radix(16))
-                        .context("Invalid dynamic param")?,
+                    Felt::from_hex(&e.1.to_str_radix(16)).context("Invalid dynamic param")?,
                 ))
             })
             .collect::<anyhow::Result<_>>()?;
@@ -199,10 +198,9 @@ impl ProofJSON {
                 stop_ptr: s.stop_ptr,
             })
             .collect::<Vec<_>>();
-        let layout =
-            FieldElement::from_hex_be(&prefix_hex::encode(public_input.layout.bytes_encode()))?;
+        let layout = Felt::from_hex(&prefix_hex::encode(public_input.layout.bytes_encode()))?;
         let (padding_addr, padding_value) = match public_input.public_memory.first() {
-            Some(m) => (m.address, FieldElement::from_hex_be(&m.value)?),
+            Some(m) => (m.address, Felt::from_hex(&m.value)?),
             None => anyhow::bail!("Invalid public memory"),
         };
         Ok(CairoPublicInput {
@@ -225,14 +223,14 @@ impl ProofJSON {
 
     fn main_page(
         public_memory: &[PublicMemoryElement],
-    ) -> anyhow::Result<Vec<PublicMemoryCell<FieldElement>>> {
+    ) -> anyhow::Result<Vec<PublicMemoryCell<Felt>>> {
         public_memory
             .iter()
             .filter(|m| m.page == 0)
             .map(|m| {
                 Ok(PublicMemoryCell {
                     address: m.address,
-                    value: FieldElement::from_hex_be(&m.value).context("Invalid memory value")?,
+                    value: Felt::from_hex(&m.value).context("Invalid memory value")?,
                 })
             })
             .collect::<anyhow::Result<Vec<_>>>()
@@ -286,7 +284,7 @@ impl ProofJSON {
 }
 
 #[derive(Debug)]
-struct HexProof(Vec<FieldElement>);
+struct HexProof(Vec<Felt>);
 
 impl TryFrom<&str> for HexProof {
     type Error = anyhow::Error;
@@ -294,7 +292,7 @@ impl TryFrom<&str> for HexProof {
         let hex: Vec<u8> = prefix_hex::decode(value).map_err(|_| anyhow!("Invalid hex"))?;
         let mut result = vec![];
         for chunk in hex.chunks(32) {
-            result.push(FieldElement::from_byte_slice_be(chunk)?);
+            result.push(Felt::from_bytes_be_slice(chunk));
         }
 
         Ok(HexProof(result))

--- a/proof-parser/src/output.rs
+++ b/proof-parser/src/output.rs
@@ -1,4 +1,5 @@
-use starknet_crypto::{poseidon_hash_many, FieldElement};
+use starknet_crypto::poseidon_hash_many;
+use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -7,8 +8,8 @@ use crate::parse_raw;
 const OUTPUT_SEGMENT_OFFSET: usize = 2;
 
 pub struct ExtractOutputResult {
-    pub program_output: Vec<FieldElement>,
-    pub program_output_hash: FieldElement,
+    pub program_output: Vec<Felt>,
+    pub program_output_hash: Felt,
 }
 
 pub fn extract_output(input: &str) -> anyhow::Result<ExtractOutputResult> {
@@ -31,16 +32,14 @@ pub fn extract_output(input: &str) -> anyhow::Result<ExtractOutputResult> {
             .chain(value_bytes.iter())
             .copied()
             .collect::<Vec<u8>>();
-        let field_element = FieldElement::from_bytes_be(
-            &padded_value.try_into().expect("Failed to convert to array"),
-        )
-        .expect("Failed to convert to FieldElement");
+        let field_element =
+            Felt::from_bytes_be(&padded_value.try_into().expect("Failed to convert to array"));
 
         main_page_map.insert(element.address, field_element);
     }
 
     // Extract program output using the address range in the output segment
-    let program_output: Vec<FieldElement> = (output_segment.begin_addr..output_segment.stop_ptr)
+    let program_output: Vec<Felt> = (output_segment.begin_addr..output_segment.stop_ptr)
         .map(|addr| {
             *main_page_map
                 .get(&addr)

--- a/proof-parser/src/program.rs
+++ b/proof-parser/src/program.rs
@@ -1,4 +1,5 @@
-use starknet_crypto::{poseidon_hash_many, FieldElement};
+use starknet_crypto::poseidon_hash_many;
+use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
@@ -8,8 +9,8 @@ const PROGRAM_SEGMENT_OFFSET: usize = 0;
 const EXECUTION_SEGMENT_OFFSET: usize = 1;
 
 pub struct ExtractProgramResult {
-    pub program: Vec<FieldElement>,
-    pub program_hash: FieldElement,
+    pub program: Vec<Felt>,
+    pub program_hash: Felt,
 }
 
 pub fn extract_program(input: &str) -> anyhow::Result<ExtractProgramResult> {
@@ -39,10 +40,8 @@ pub fn extract_program(input: &str) -> anyhow::Result<ExtractProgramResult> {
             .chain(value_bytes.iter())
             .copied()
             .collect::<Vec<u8>>();
-        let field_element = FieldElement::from_bytes_be(
-            &padded_value.try_into().expect("Failed to convert to array"),
-        )
-        .expect("Failed to convert to FieldElement");
+        let field_element =
+            Felt::from_bytes_be(&padded_value.try_into().expect("Failed to convert to array"));
 
         main_page_map.insert(element.address, field_element);
     }
@@ -51,7 +50,7 @@ pub fn extract_program(input: &str) -> anyhow::Result<ExtractProgramResult> {
     let initial_fp = execution_segment.begin_addr;
 
     // Extract program bytecode using the address range in the segments
-    let program: Vec<FieldElement> = (initial_pc..(initial_fp - initial_pc - 1))
+    let program: Vec<Felt> = (initial_pc..(initial_fp - initial_pc - 1))
         .map(|addr| {
             *main_page_map
                 .get(&addr)

--- a/proof-parser/src/proof_structure.rs
+++ b/proof-parser/src/proof_structure.rs
@@ -143,6 +143,8 @@ impl ProofStructure {
 
 #[test]
 fn test_lens() {
+    use crate::proof_params::Fri;
+
     // let n_steps = 16384;
     let layout = Layout::Recursive;
     let proof_params = ProofParameters {

--- a/proof-parser/src/stark_proof.rs
+++ b/proof-parser/src/stark_proof.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use starknet_crypto::FieldElement;
+use starknet_types_core::felt::Felt;
 
 use serde_felt::deserialize_montgomery_vec;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct StarkProof {
     pub config: StarkConfig,
-    pub public_input: CairoPublicInput<FieldElement>,
+    pub public_input: CairoPublicInput<Felt>,
     pub unsent_commitment: StarkUnsentCommitment,
     pub witness: StarkWitnessReordered,
 }
@@ -60,52 +60,52 @@ pub struct ProofOfWorkConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StarkUnsentCommitment {
     pub traces: TracesUnsentCommitment,
-    pub composition: FieldElement,
-    pub oods_values: Vec<FieldElement>,
+    pub composition: Felt,
+    pub oods_values: Vec<Felt>,
     pub fri: FriUnsentCommitment,
-    pub proof_of_work_nonce: FieldElement,
+    pub proof_of_work_nonce: Felt,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TracesUnsentCommitment {
-    pub original: FieldElement,
-    pub interaction: FieldElement,
+    pub original: Felt,
+    pub interaction: Felt,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FriUnsentCommitment {
-    pub inner_layers: Vec<FieldElement>,
-    pub last_layer_coefficients: Vec<FieldElement>,
+    pub inner_layers: Vec<Felt>,
+    pub last_layer_coefficients: Vec<Felt>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct StarkWitness {
     #[serde(deserialize_with = "deserialize_montgomery_vec")]
-    pub original_leaves: Vec<FieldElement>,
-    pub original_authentications: Vec<FieldElement>,
+    pub original_leaves: Vec<Felt>,
+    pub original_authentications: Vec<Felt>,
     #[serde(deserialize_with = "deserialize_montgomery_vec")]
-    pub interaction_leaves: Vec<FieldElement>,
-    pub interaction_authentications: Vec<FieldElement>,
+    pub interaction_leaves: Vec<Felt>,
+    pub interaction_authentications: Vec<Felt>,
     #[serde(deserialize_with = "deserialize_montgomery_vec")]
-    pub composition_leaves: Vec<FieldElement>,
-    pub composition_authentications: Vec<FieldElement>,
+    pub composition_leaves: Vec<Felt>,
+    pub composition_authentications: Vec<Felt>,
     pub fri_witness: FriWitness,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct StarkWitnessReordered {
     #[serde(serialize_with = "double_len_serialize")]
-    pub original_leaves: Vec<FieldElement>,
+    pub original_leaves: Vec<Felt>,
     #[serde(serialize_with = "double_len_serialize")]
-    pub interaction_leaves: Vec<FieldElement>,
+    pub interaction_leaves: Vec<Felt>,
     #[serde(serialize_with = "double_len_serialize")]
-    pub original_authentications: Vec<FieldElement>,
+    pub original_authentications: Vec<Felt>,
     #[serde(serialize_with = "double_len_serialize")]
-    pub interaction_authentications: Vec<FieldElement>,
+    pub interaction_authentications: Vec<Felt>,
     #[serde(serialize_with = "double_len_serialize")]
-    pub composition_leaves: Vec<FieldElement>,
+    pub composition_leaves: Vec<Felt>,
     #[serde(serialize_with = "double_len_serialize")]
-    pub composition_authentications: Vec<FieldElement>,
+    pub composition_authentications: Vec<Felt>,
     pub fri_witness: FriWitness,
 }
 
@@ -123,7 +123,7 @@ impl From<StarkWitness> for StarkWitnessReordered {
     }
 }
 
-pub fn double_len_serialize<S>(value: &[FieldElement], serializer: S) -> Result<S::Ok, S::Error>
+pub fn double_len_serialize<S>(value: &[Felt], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
@@ -148,8 +148,8 @@ pub struct FriWitness {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FriLayerWitness {
     #[serde(deserialize_with = "deserialize_montgomery_vec")]
-    pub leaves: Vec<FieldElement>,
-    pub table_witness: Vec<FieldElement>,
+    pub leaves: Vec<Felt>,
+    pub table_witness: Vec<Felt>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/serde-felt/Cargo.toml
+++ b/serde-felt/Cargo.toml
@@ -5,5 +5,4 @@ edition.workspace = true
 
 [dependencies]
 serde.workspace = true
-starknet-crypto.workspace = true
-starknet-ff.workspace = true
+starknet-types-core.workspace = true

--- a/serde-felt/src/deser.rs
+++ b/serde-felt/src/deser.rs
@@ -2,31 +2,31 @@ use std::collections::HashMap;
 
 use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
 use serde::Deserialize;
-use starknet_crypto::FieldElement;
+use starknet_types_core::felt::Felt;
 
 use super::error::{Error, Result};
 
 pub type Lengths = HashMap<String, Vec<usize>>;
 
 pub struct Deserializer<'de> {
-    input: &'de [FieldElement],
+    input: &'de [Felt],
     lengths: Option<Lengths>, // Workaround around serde limit to 32 element tuples.
     next_length: Option<usize>,
 }
 
 impl<'de> Deserializer<'de> {
-    pub fn peek(&self) -> Result<FieldElement> {
+    pub fn peek(&self) -> Result<Felt> {
         self.input.first().copied().ok_or(Error::NoDataLeft)
     }
 
-    pub fn take(&mut self) -> Result<FieldElement> {
+    pub fn take(&mut self) -> Result<Felt> {
         let el = self.peek()?;
         self.input = &self.input[1..];
 
         Ok(el)
     }
 
-    pub fn from_felts(input: &'de Vec<FieldElement>) -> Self {
+    pub fn from_felts(input: &'de Vec<Felt>) -> Self {
         Deserializer {
             input,
             lengths: None,
@@ -34,7 +34,7 @@ impl<'de> Deserializer<'de> {
         }
     }
 
-    pub fn from_felts_with_lengths(input: &'de Vec<FieldElement>, lengths: Lengths) -> Self {
+    pub fn from_felts_with_lengths(input: &'de Vec<Felt>, lengths: Lengths) -> Self {
         Deserializer {
             input,
             lengths: Some(lengths),
@@ -67,21 +67,21 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-pub fn from_felts<'a, T>(s: &'a Vec<FieldElement>) -> Result<T>
+pub fn from_felts<'a, T>(s: &'a Vec<Felt>) -> Result<T>
 where
     T: Deserialize<'a>,
 {
     from_felts_inner(s, None)
 }
 
-pub fn from_felts_with_lengths<'a, T>(s: &'a Vec<FieldElement>, lengths: Lengths) -> Result<T>
+pub fn from_felts_with_lengths<'a, T>(s: &'a Vec<Felt>, lengths: Lengths) -> Result<T>
 where
     T: Deserialize<'a>,
 {
     from_felts_inner(s, Some(lengths))
 }
 
-fn from_felts_inner<'a, T>(s: &'a Vec<FieldElement>, lengths: Option<Lengths>) -> Result<T>
+fn from_felts_inner<'a, T>(s: &'a Vec<Felt>, lengths: Option<Lengths>) -> Result<T>
 where
     T: Deserialize<'a>,
 {

--- a/serde-felt/src/deser.rs
+++ b/serde-felt/src/deser.rs
@@ -224,7 +224,8 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_string(self.take()?.to_string())
+        let hex = format!("{:#x}", self.take()?);
+        visitor.visit_string(hex)
     }
 
     fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>

--- a/serde-felt/src/montgomery.rs
+++ b/serde-felt/src/montgomery.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer};
-use starknet_crypto::FieldElement;
+use starknet_types_core::felt::Felt;
 
-pub fn montgomery_to_felt(montgomery_felt: FieldElement) -> FieldElement {
+pub fn montgomery_to_felt(montgomery_felt: Felt) -> Felt {
     let dd: Vec<u64> = montgomery_felt
         .to_bytes_be()
         .chunks(8)
@@ -16,24 +16,25 @@ pub fn montgomery_to_felt(montgomery_felt: FieldElement) -> FieldElement {
 
     let mut bytes = [0u64; 4];
     bytes.copy_from_slice(&dd);
-    FieldElement::from_mont(bytes)
+    bytes.reverse();
+
+    Felt::from_raw(bytes)
 }
 
-pub fn deserialize_montgomery<'de, D>(de: D) -> Result<FieldElement, D::Error>
+pub fn deserialize_montgomery<'de, D>(de: D) -> Result<Felt, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let incorrectly_deserialized_felt =
-        FieldElement::deserialize(de).map_err(serde::de::Error::custom)?;
+    let incorrectly_deserialized_felt = Felt::deserialize(de).map_err(serde::de::Error::custom)?;
     Ok(montgomery_to_felt(incorrectly_deserialized_felt))
 }
 
-pub fn deserialize_montgomery_vec<'de, D>(de: D) -> Result<Vec<FieldElement>, D::Error>
+pub fn deserialize_montgomery_vec<'de, D>(de: D) -> Result<Vec<Felt>, D::Error>
 where
     D: Deserializer<'de>,
 {
     let incorrectly_deserialized_felts =
-        Vec::<FieldElement>::deserialize(de).map_err(serde::de::Error::custom)?;
+        Vec::<Felt>::deserialize(de).map_err(serde::de::Error::custom)?;
 
     Ok(incorrectly_deserialized_felts
         .into_iter()
@@ -46,6 +47,6 @@ fn test() {
     let expected = "0x00f2e6af983ae40f9d409cbc81a3a9f70ce2ef9ccd2d2018aba74f3a77406193";
     let got = "0x004b372a6c0acf83dd330cdf701e5dc85726b19819d4b33158dcb57a33f704c7";
 
-    let felt = montgomery_to_felt(FieldElement::from_hex_be(got).unwrap());
-    assert_eq!(felt, FieldElement::from_hex_be(expected).unwrap());
+    let felt = montgomery_to_felt(Felt::from_hex(got).unwrap());
+    assert_eq!(felt, Felt::from_hex(expected).unwrap());
 }

--- a/serde-felt/src/ser.rs
+++ b/serde-felt/src/ser.rs
@@ -1,10 +1,10 @@
 use serde::{ser, Serialize};
-use starknet_crypto::FieldElement;
+use starknet_types_core::felt::Felt;
 
 use super::error::{Error, Result};
 
 pub struct Serializer {
-    output: Vec<FieldElement>,
+    output: Vec<Felt>,
 }
 
 pub struct SeqSerializer<'a> {
@@ -12,7 +12,7 @@ pub struct SeqSerializer<'a> {
     len_index: usize,
 }
 
-pub fn to_felts<T>(value: &T) -> Result<Vec<FieldElement>>
+pub fn to_felts<T>(value: &T) -> Result<Vec<Felt>>
 where
     T: Serialize,
 {
@@ -68,7 +68,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        self.output.push(FieldElement::from(v));
+        self.output.push(Felt::from(v));
         Ok(())
     }
 
@@ -85,7 +85,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        let felt = FieldElement::from_dec_str(v).map_err(|_| Error::UnparsableString)?;
+        let felt = Felt::from_dec_str(v).map_err(|_| Error::UnparsableString)?;
         self.output.push(felt);
         Ok(())
     }
@@ -152,7 +152,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
         let len = len.ok_or(Error::LengthNotKnownAtSerialization)?;
         let len_index = self.output.len();
-        self.output.push(FieldElement::from(len)); // This is later overwritten with the actual length
+        self.output.push(Felt::from(len)); // This is later overwritten with the actual length
 
         Ok(SeqSerializer {
             se: self,
@@ -215,8 +215,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
     }
 
     fn end(self) -> Result<()> {
-        self.se.output[self.len_index] =
-            FieldElement::from(self.se.output.len() - self.len_index - 1);
+        self.se.output[self.len_index] = Felt::from(self.se.output.len() - self.len_index - 1);
         Ok(())
     }
 }

--- a/serde-felt/src/ser.rs
+++ b/serde-felt/src/ser.rs
@@ -85,7 +85,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
-        let felt = Felt::from_dec_str(v).map_err(|_| Error::UnparsableString)?;
+        let felt = Felt::from_hex(v).map_err(|_| Error::UnparsableString)?;
         self.output.push(felt);
         Ok(())
     }

--- a/serde-felt/src/tests.rs
+++ b/serde-felt/src/tests.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use starknet_ff::FieldElement;
+use starknet_types_core::felt::Felt;
 
 use crate::{from_felts, from_felts_with_lengths, to_felts};
 
@@ -7,27 +7,27 @@ use super::error::Result;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Basic {
-    a: FieldElement,
-    b: FieldElement,
+    a: Felt,
+    b: Felt,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Nested {
-    a: FieldElement,
+    a: Felt,
     b: Basic,
-    c: FieldElement,
+    c: Felt,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct WithSequence {
-    a: Vec<FieldElement>,
-    b: FieldElement,
+    a: Vec<Felt>,
+    b: Felt,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct WithArray {
-    a: [FieldElement; 2],
-    b: FieldElement,
+    a: [Felt; 2],
+    b: Felt,
 }
 
 #[test]


### PR DESCRIPTION
to unify the new felt types throughout dojo 

Because Dojo is using [tag:v0.3.0](https://github.com/cartridge-gg/cairo-proof-parser/tree/v0.3.0), i have a branch that builds on top of it [v0.3.0/new-felt](https://github.com/cartridge-gg/cairo-proof-parser/tree/v0.3.0/new-felt) which i did similar migration as this PR. So for now, Dojo would likely be using that branch to complete the migration.